### PR TITLE
Add keyboard context menu fix plugin

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -1806,5 +1806,12 @@
         "author": "kurakart",
         "description": "Garbling text in Obsidian turns all content in the entire app (notes, sidebar, etc) into lines so you can take screenshots without exposing sensitive data.",
         "repo": "kurakart/garble-text"
+    },
+    {
+        "id": "obsidian-keyboard-context-menu-fix-plugin",
+        "name": "keyboard Context Menu Fix",
+        "author": "Sam Greenhalgh",
+        "description": "Fixes keyboard navigation of spelling suggestion context menu.",
+        "repo": "zapthedingbat/obsidian-keyboard-context-menu-fix-plugin"
     }
 ]


### PR DESCRIPTION
<!--- Delete this section if submitting a theme -->
# [x] I am submitting a new Community Plugin

## Repo URL

https://github.com/zapthedingbat/obsidian-keyboard-context-menu-fix-plugin

## Release Checklist

<!--- Confirm that you have done the following before submitting your plugin -->
- [x] I have tested this on Windows, macOS, and Linux _(if applicable)_
- [x] Github release contains all required files
  - [x] `main.js`
  - [x] `manifest.json`
  - [x] `styles.css` _(optional)_
- [x] Github release name matches the exact version number specified in my manifest.json (_**Note:** Use the exact version number, don't include a prefix `v`_)
- [x] The `id` in my `manifest.json` matches the `id` in the `community-plugins.json` file.
- [x] README clearly describes the plugins purpose and provides clear usage instructions.
- [x] I have added a license in the LICENSE file
